### PR TITLE
FIX: Pin to newer version of act

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - numpy
   - xarray
   - metpy
-  - act-atmos
+  - act-atmos>=1.2.0
   - imageio
   - pip
   - pip:


### PR DESCRIPTION
We need to use the newer versions of ACT in order to use to refined search functionality.

Closes #71 