### PR TITLE
Fix link to binder in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 # Radar Cookbook
 
 [![nightly-build](https://github.com/ProjectPythiaCookbooks/radar-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythiaCookbooks/radar-cookbook/actions/workflows/nightly-build.yaml)
-[![Binder](https://aws-uswest2-binder.pangeo.io/badge_logo.svg)](https://aws-uswest2-binder.pangeo.io/v2/gh/ProjectPythiaCookbooks/radar-cookbook/main?labpath=notebooks)
+[![Binder](http://binder.mypythia.org/badge_logo.svg)](http://binder.mypythia.org/v2/gh/ProjectPythiaCookbooks/radar-cookbook/main?labpath=notebooks)
+
+This Project Pythia Cookbook covers the basics of working with weather radar data in Python.
 
 This Project Pythia Cookbook covers the basics of working with weather radar data in Python.
 


### PR DESCRIPTION
Use the Project Pythia binder for launch button on README.

Closes #78 